### PR TITLE
Fix issue with empty checkValue when importing CSV

### DIFF
--- a/src/CommunityStore/Shipping/Method/Types/TablerateShippingMethod.php
+++ b/src/CommunityStore/Shipping/Method/Types/TablerateShippingMethod.php
@@ -149,8 +149,8 @@
           $uData[] = $smID;
           $uData[] = $row[0];
           $uData[] = $row[1];
-          $uData[] = $row[3];
-          $uData[] = $row[4];
+          $uData[] = (float) $row[3]; // otherwise empty values throw an error as they are empty strings and the DB expects a float
+          $uData[] = $row[4]; // no problem here as the DB expects a string
           $db->Execute('insert into CommunityStoreTablerateConditions (trID, country, state, checkValue, shippingPrice) values (?,?,?,?,?)', $uData);
         }else{
           $skipFirst++;


### PR DESCRIPTION
in the database, checkValue expects a float value so when the CSV value is empty the database throws an error trying to save an empty string. simply typecasting the value before saving fixes that. No adverse effect that I could see.